### PR TITLE
Bugfix for undetected start of recording

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.0.13
+- Bugfix for undetected start of recording
+
 0.0.12
 - small Bugfix
 

--- a/service.py
+++ b/service.py
@@ -142,7 +142,7 @@ class Manager(object):
 
         # Check for PVR events
         _flags |= self.get_pvr_events(_flags)
-        if self.wakeREC and (self.wakeREC - __curTime).seconds < \
+        if self.wakeREC and (__curTime - self.wakeREC).seconds < \
                 getAddonSetting('margin_start', sType=NUM) + getAddonSetting('margin_stop', sType=NUM):
             _flags |= isREC
             writeLog(self.rndProcNum, 'Next timer starts immediately (%s)' % str(self.wakeREC))


### PR DESCRIPTION
The python script didn't detect the start of a recording. So the script stopped right after starting. I made a very little adjustment and now it works (I think).
Greetings, SA Fokkens