### PR TITLE
Skip empty lines in /etc/os-release

### DIFF
--- a/resources/lib/tools.py
+++ b/resources/lib/tools.py
@@ -48,8 +48,9 @@ def release():
     if coll['platform'] == 'Linux':
         with open('/etc/os-release', 'r') as _file:
             for _line in _file:
-                parameter, value = _line.split('=')
-                item[parameter] = value.replace('"', '').strip()
+                if '=' in _line:
+                    parameter, value = _line.split('=')
+                    item[parameter] = value.replace('"', '').strip()
 
     coll.update({'osname': item.get('NAME', ''), 'osid': item.get('ID', ''), 'osversion': item.get('VERSION_ID', '')})
     return coll


### PR DESCRIPTION
Some /etc/os-release files have empty lines (like the OSMC vero4k development branch). This results in:
```
22:57:38.453 T:2952778480   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.ValueError'>
                                            Error Contents: need more than 1 value to unpack
                                            Traceback (most recent call last):
                                              File "/home/osmc/.kodi/addons/service.tvh.manager/default.py", line 11, in <module>
                                                release = tools.release()
                                              File "/home/osmc/.kodi/addons/service.tvh.manager/resources/lib/tools.py", line 47, in __init__
                                                parameter, value = _line.split('=')
                                            ValueError: need more than 1 value to unpack
                                            -->End of Python script error report<--
```